### PR TITLE
RPM port

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+permissions:
+  contents: write
+  statuses: write
+  actions: read
+
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'cicd*.groovy'
+      - '**/LICENSE'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/run tests')) || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
+    uses: zopencommunity/meta/.github/workflows/build_and_test.yml@main
+    secrets: inherit

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,21 @@
+name: 'Automatic version updates'
+
+permissions:
+  contents: write
+  statuses: write
+  actions: read
+
+on:
+  schedule:
+    # minute hour dom month dow (UTC)
+    - cron: '00 15 * * *'
+  # enable manual trigger of version updates
+  workflow_dispatch:
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: zopencommunity/meta/actions@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+log/
+log.DEV/
+log.STABLE/
+build/
+install/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These members will be default reviewers for each repo
+* @IgorTodorovskiIBM @MikeFultonDev @DevonianTeuchter @HarithaIBM @v1gnesh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+## Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, and
+any additional policies about what to include will be provided in the responses. The only
+exception is security disclosures which should be sent privately.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue is addressed.
+
+## Contributions
+
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc.
+
+No pull request can be merged without being reviewed and approved.
+
+## Validate your changes
+
+Verify that the project is working by running `zopen build`.
+
+## Coding Guidelines
+
+When contributing your changes, please follow the following coding guidelines:
+* patches: patches should adhere to the coding guidelines from the original project repository. Make sure to add the original project's LICENSE file within the patches
+directory.
+* zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+If you are generating a new project, we recommend that you use `zopen generate` to create the correct zopen file and directory structure.
+
+### Commit message
+
+A good commit message should describe what changed and why.
+
+It should:
+  * contain a short description of the change
+  * be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer to code, like function/variable names
+  * be prefixed with one of the following words:
+    * fix: bug fix
+    * hotfix: urgent bug fix
+    * feat: new or updated feature
+    * docs: documentation updates
+    * refactor: code refactoring (no functional change)
+    * perf: performance improvement
+    * test: tests and CI updates
+
+### Developer's Certificate of Origin 1.1
+
+<pre>
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+</pre>

--- a/buildenv
+++ b/buildenv
@@ -1,0 +1,75 @@
+# Update bump details accordingly. Use bump check to confirm.
+# bump: RPM-version /RPM_VERSION="(.*)"/ https://github.com/rpm-software-management/rpm.git|semver:*
+# RPM_VERSION="V.R.M" # Specify a stable release
+# export ZOPEN_STABLE_TAG="v${RPM_VERSION}"
+
+export ZOPEN_BUILD_LINE="STABLE"
+export ZOPEN_STABLE_URL="https://github.com/rpm-software-management/rpm.git"  
+export ZOPEN_STABLE_DEPS="cpio libgpgerror zstd popt readline lua pkgconfig cmake zlib unzip libarchive scdoc libgcrypt openssl sqlite bzip2 gzip xz gettext make autoconf automake libtool perl m4 tar gpg doxygen lz4" 
+
+export ZOPEN_DEV_URL="https://github.com/rpm-software-management/rpm.git"   
+export ZOPEN_STABLE_DEPS="libgpgerror  zstd popt readline lua pkgconfig cmake zlib unzip libarchive scdoc libgcrypt openssl sqlite bzip2 gzip xz gettext make autoconf automake libtool perl m4 tar gpg doxygen lz4"
+
+export ZOPEN_EXTRA_CFLAGS="-mzos-target=zosv2r5 -march=z13 -D_POSIX_C_SOURCE=200809L" 
+export ZOPEN_EXTRA_CPPFLAGS="-mzos-target=zosv2r5 -march=z13 -D_POSIX_C_SOURCE=200809L"  
+export ZOPEN_SYSTEM_PREREQS="zos25"
+export PKG_CONFIG_PATH="/data/zopen/usr/local/lib/pkgconfig"
+
+export ZOPEN_CATEGORIES="core utilities"
+
+export ZOPEN_RUNTIME_DEPS="bash"
+
+export ZOPEN_SYSTEM_PREREQ=""
+
+export ZOPEN_COMP="CLANG"
+export ZOPEN_BOOTSTRAP="skip" 
+export ZOPEN_CONFIGURE="cmake"  
+export ZOPEN_MAKE="zopen_build"
+
+zopen_build() {
+  # Change to release for debug
+  LIBPATH="$LPEG_HOME/lib:$LIBPATH" make "$@" CMAKE_INSTALL_PREFIX="$ZOPEN_INSTALL_DIR" CMAKE_BUILD_TYPE=Release CMAKE_EXTRA_FLAGS="-DEXTRA_CFLAGS=\"-isystem${ZOSLIB_HOME}/include $CPPFLAGS\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=${CXX}  -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS=\"${CPPFLAGS} ${CFLAGS}\" -DCMAKE_C_FLAGS_RELEASE=\"${CPPFLAGS} ${CFLAGS}\" -DCOMPILE_FLAGS=\"${CPPFLAGS} ${CFLAGS}\" -DCMAKE_CXX_FLAGS=\"${CPPFLAGS} ${CFLAGS}\"  -DCMAKE_CXX_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DCMAKE_C_LINK_LIBRARY_FLAG=\"${LDFLAGS}\" -DCMAKE_CXX_STANDARD_LIBRARIES=\"${LIBS}\"  -DCMAKE_C_STANDARD_LIBRARIES=\"${LIBS}\" -DPREFER_LUA=ON -DENABLE_LIBINTL=OFF -DLIBUV_INCLUDE_DIR=\"$LIBUV_HOME/include\" -DGETTEXT_INCLUDE_DIR="$GETTEXT_HOME/include" -DGETTEXT_LIBRARIES="$GETTEXT_HOME/lib"  -DLIBUV_LIBRARY=\"$LIBUV_HOME/lib\" -DLPEG_LIBRARY="$LPEG_HOME/lib/lpeg.x"" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED=OFF -DLIBUV_LIBRARIES="$LIBUV_HOME/lib" -DLIBUV_LIBRARY="$LIBUV_HOME/lib/libuv.a" -DLIBUV_INCLUDE_DIR="$LIBUV_HOME/include" -DUSE_BUNDLED_LUA=ON -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_TS=ON -DUSE_BUNDLED_TS_PARSERS=ON -DUSE_BUNDLED_LIBVTERM=ON -DUSE_BUNDLED_LPEG=OFF -DUSE_BUNDLED_LIBUV=OFF -DUSE_BUNDLED_MSGPACK=ON -DUSE_BUNDLED_UNIBILIUM=ON -DUSE_BUNDLED_UTF8PROC=ON -DENABLE_LIBINTL=OFF -DUSE_BUNDLED_GETTEXT=OFF" DEPS_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD_LIBRARIES=\"${LIBS}\" -DCMAKE_CXX_STANDARD_LIBRARIES=\"${LIBS}\" -DCMAKE_CXX_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DCMAKE_C_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DZSTD_LIBRARY=\$ZSTD_HOME/lib/libzstd.a -DZSTD_INCLUDE_DIR=\$ZSTD_HOME/include "
+}
+
+zopen_check_results()
+{
+  dir="$1"
+  pfx="$2"
+  chk="$1/$2_check.log"
+
+  # Echo the following information to gauge build health
+  echo "actualFailures:0"
+  echo "totalTests:1"
+  echo "expectedFailures:0"
+  echo "expectedTotalTests:1"
+}
+export ZOPEN_CONFIGURE_OPTS="--install-prefix \$ZOPEN_INSTALL_DIR/ -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_SYSTEM_PREFIX_PATH=/data/zopen/usr/local/zopen/ -DZLIB_LIBRARY=\"\$ZLIB_HOME/lib/libz.a\" -DLUA_DIR=/data/zopen/usr/local/zopen/lua/lua -DLUA_LIBRARIES=/data/zopen/usr/local/zopen/lua/lua/lib/liblua.a -DLUA_INCLUDE_DIR=/data/zopen/usr/local/zopen/lua/lua-5.4.7.20250530_092323.zos/include -DBZIP2_INCLUDE_DIR=/data/zopen/usr/local/zopen/bzip2/bzip2/include -DBZIP2_LIBRARIES=/data/zopen/usr/local/zopen/bzip2/bzip2/lib/libbz2.a -DLIBARCHIVE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive -DLIBARCHIVE_INCLUDE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive/include -DLIBARCHIVE_LIBRARY=/data/zopen/usr/local/zopen/libarchive/libarchive/lib/libarchive.a -DMAGIC_LIBRARY=/data/work/rpm/fileport/file-5.46/src/.libs/libmagic.a -DMAGIC_INCLUDE_DIR=/data/work/rpm/fileport/file-5.46/src -DINTL_LIBRARY=/data/zopen/usr/local/zopen/gettext/gettext-0.21.20240922_014617.zos/lib/libintl.a -DINTL_INCLUDE_DIR=/data/zopen/usr/local/zopen/gettext/gettext-0.21.20240922_014617.zos/include/libintl.h -DWITH_READLINE=OFF  -DWITH_LIBELF=OFF -DWITH_LIBDW=OFF -DWITH_LIBLZMA=OFF -DENABLE_OPENMP=OFF -DWITH_CAP=OFF -DWITH_ACL=OFF -DWITH_AUDIT=OFF -DWITH_SELINUX=OFF -DWITH_SEQUOIA=OFF -DWITH_DBUS=OFF -DZSTD_INCLUDE_DIR=\"\${ZSTD_HOME}/include\" -DZSTD_LIBRARY=\"\${ZSTD_HOME}/lib\" -DHAVE_UNSHARE=OFF -DENABLE_PYTHON=OFF"
+
+zopen_append_to_env()
+{
+cat <<ZZ
+if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
+  export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -llua"
+  export PKG_CONFIG_PATH="/data/zopen/usr/local/lib/pkgconfig"
+  export PKG_CONFIG_PATH="/data/zopen/usr/local/zopen/popt/popt-master/lib/pkgconfig/"
+  export PKG_CONFIG_PATH="/data/work/rpm/libarchiveport/libarchive/build/pkgconfig"
+
+export PKG_CONFIG_PATH="/data/zopen/usr/local/zopen/popt/popt-master/lib/pkgconfig/:/data/zopen/usr/local/zopen/libarchive/lib/pkgconfig/:\${PKG_CONFIG_PATH}"
+
+
+  # Lua configuration for CMake
+  export LUA_DIR=/data/zopen/usr/local/zopen/lua/lua
+  export LUA_LIBRARIES=/data/zopen/usr/local/zopen/lua/lua/lib/liblua.a
+  export LUA_INCLUDE_DIR=/data/zopen/usr/local/zopen/lua/lua/include
+
+  # Libarchive configuration for CMake
+  export LIBARCHIVE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive
+  export LIBARCHIVE_LIBRARIES=/data/zopen/usr/local/zopen/libarchive/libarchive/lib/libarchive.a
+  export LIBARCHIVE_INCLUDE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive/include
+
+fi
+ZZ
+}
+

--- a/buildenv
+++ b/buildenv
@@ -3,17 +3,22 @@
 # RPM_VERSION="V.R.M" # Specify a stable release
 # export ZOPEN_STABLE_TAG="v${RPM_VERSION}"
 
-export ZOPEN_BUILD_LINE="STABLE"
-export ZOPEN_STABLE_URL="https://github.com/rpm-software-management/rpm.git"  
-export ZOPEN_STABLE_DEPS="cpio libgpgerror zstd popt readline lua pkgconfig cmake zlib unzip libarchive scdoc libgcrypt openssl sqlite bzip2 gzip xz gettext make autoconf automake libtool perl m4 tar gpg doxygen lz4" 
+echo $ZOPEN_INSTALL_DIR
 
-export ZOPEN_DEV_URL="https://github.com/rpm-software-management/rpm.git"   
-export ZOPEN_STABLE_DEPS="libgpgerror  zstd popt readline lua pkgconfig cmake zlib unzip libarchive scdoc libgcrypt openssl sqlite bzip2 gzip xz gettext make autoconf automake libtool perl m4 tar gpg doxygen lz4"
+export ZOPEN_BUILD_LINE="STABLE"
+
+export ZOPEN_STABLE_URL="https://github.com/rpm-software-management/rpm.git"  # Specify the stable build URL (either git or tarball)
+export ZOPEN_STABLE_DEPS="coreutils zstd unzip git gawk patch grep sed file xz tar grep cpio libgpgerror zstd popt readline lua pkgconfig cmake zlib unzip libarchive scdoc libgcrypt openssl sqlite bzip2 gzip xz gettext make autoconf automake libtool perl m4 tar gpg doxygen lz4" # Specify the stable build dependencies.
+
+## Required IF ZOPEN_BUILD_LINE='DEV'
+export ZOPEN_DEV_URL="https://github.com/rpm-software-management/rpm.git"   # Specify the dev build URL
+
 
 export ZOPEN_EXTRA_CFLAGS="-mzos-target=zosv2r5 -march=z13 -D_POSIX_C_SOURCE=200809L" 
 export ZOPEN_EXTRA_CPPFLAGS="-mzos-target=zosv2r5 -march=z13 -D_POSIX_C_SOURCE=200809L"  
 export ZOPEN_SYSTEM_PREREQS="zos25"
 export PKG_CONFIG_PATH="/data/zopen/usr/local/lib/pkgconfig"
+
 
 export ZOPEN_CATEGORIES="core utilities"
 
@@ -22,12 +27,13 @@ export ZOPEN_RUNTIME_DEPS="bash"
 export ZOPEN_SYSTEM_PREREQ=""
 
 export ZOPEN_COMP="CLANG"
-export ZOPEN_BOOTSTRAP="skip" 
-export ZOPEN_CONFIGURE="cmake"  
+export ZOPEN_BOOTSTRAP="skip"  ## Bootstrap program to run (defaults to './bootstrap')
+export ZOPEN_CONFIGURE="cmake" ## Configuration program to run (defaults to './configure')
+
 export ZOPEN_MAKE="zopen_build"
 
+
 zopen_build() {
-  # Change to release for debug
   LIBPATH="$LPEG_HOME/lib:$LIBPATH" make "$@" CMAKE_INSTALL_PREFIX="$ZOPEN_INSTALL_DIR" CMAKE_BUILD_TYPE=Release CMAKE_EXTRA_FLAGS="-DEXTRA_CFLAGS=\"-isystem${ZOSLIB_HOME}/include $CPPFLAGS\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=${CXX}  -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS=\"${CPPFLAGS} ${CFLAGS}\" -DCMAKE_C_FLAGS_RELEASE=\"${CPPFLAGS} ${CFLAGS}\" -DCOMPILE_FLAGS=\"${CPPFLAGS} ${CFLAGS}\" -DCMAKE_CXX_FLAGS=\"${CPPFLAGS} ${CFLAGS}\"  -DCMAKE_CXX_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DCMAKE_C_LINK_LIBRARY_FLAG=\"${LDFLAGS}\" -DCMAKE_CXX_STANDARD_LIBRARIES=\"${LIBS}\"  -DCMAKE_C_STANDARD_LIBRARIES=\"${LIBS}\" -DPREFER_LUA=ON -DENABLE_LIBINTL=OFF -DLIBUV_INCLUDE_DIR=\"$LIBUV_HOME/include\" -DGETTEXT_INCLUDE_DIR="$GETTEXT_HOME/include" -DGETTEXT_LIBRARIES="$GETTEXT_HOME/lib"  -DLIBUV_LIBRARY=\"$LIBUV_HOME/lib\" -DLPEG_LIBRARY="$LPEG_HOME/lib/lpeg.x"" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED=OFF -DLIBUV_LIBRARIES="$LIBUV_HOME/lib" -DLIBUV_LIBRARY="$LIBUV_HOME/lib/libuv.a" -DLIBUV_INCLUDE_DIR="$LIBUV_HOME/include" -DUSE_BUNDLED_LUA=ON -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_TS=ON -DUSE_BUNDLED_TS_PARSERS=ON -DUSE_BUNDLED_LIBVTERM=ON -DUSE_BUNDLED_LPEG=OFF -DUSE_BUNDLED_LIBUV=OFF -DUSE_BUNDLED_MSGPACK=ON -DUSE_BUNDLED_UNIBILIUM=ON -DUSE_BUNDLED_UTF8PROC=ON -DENABLE_LIBINTL=OFF -DUSE_BUNDLED_GETTEXT=OFF" DEPS_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD_LIBRARIES=\"${LIBS}\" -DCMAKE_CXX_STANDARD_LIBRARIES=\"${LIBS}\" -DCMAKE_CXX_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DCMAKE_C_LINK_LIBRARY_FLAG=\"${LDFLAGS}\"  -DZSTD_LIBRARY=\$ZSTD_HOME/lib/libzstd.a -DZSTD_INCLUDE_DIR=\$ZSTD_HOME/include "
 }
 
@@ -43,7 +49,8 @@ zopen_check_results()
   echo "expectedFailures:0"
   echo "expectedTotalTests:1"
 }
-export ZOPEN_CONFIGURE_OPTS="--install-prefix \$ZOPEN_INSTALL_DIR/ -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_SYSTEM_PREFIX_PATH=/data/zopen/usr/local/zopen/ -DZLIB_LIBRARY=\"\$ZLIB_HOME/lib/libz.a\" -DLUA_DIR=/data/zopen/usr/local/zopen/lua/lua -DLUA_LIBRARIES=/data/zopen/usr/local/zopen/lua/lua/lib/liblua.a -DLUA_INCLUDE_DIR=/data/zopen/usr/local/zopen/lua/lua-5.4.7.20250530_092323.zos/include -DBZIP2_INCLUDE_DIR=/data/zopen/usr/local/zopen/bzip2/bzip2/include -DBZIP2_LIBRARIES=/data/zopen/usr/local/zopen/bzip2/bzip2/lib/libbz2.a -DLIBARCHIVE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive -DLIBARCHIVE_INCLUDE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive/include -DLIBARCHIVE_LIBRARY=/data/zopen/usr/local/zopen/libarchive/libarchive/lib/libarchive.a -DMAGIC_LIBRARY=/data/work/rpm/fileport/file-5.46/src/.libs/libmagic.a -DMAGIC_INCLUDE_DIR=/data/work/rpm/fileport/file-5.46/src -DINTL_LIBRARY=/data/zopen/usr/local/zopen/gettext/gettext-0.21.20240922_014617.zos/lib/libintl.a -DINTL_INCLUDE_DIR=/data/zopen/usr/local/zopen/gettext/gettext-0.21.20240922_014617.zos/include/libintl.h -DWITH_READLINE=OFF  -DWITH_LIBELF=OFF -DWITH_LIBDW=OFF -DWITH_LIBLZMA=OFF -DENABLE_OPENMP=OFF -DWITH_CAP=OFF -DWITH_ACL=OFF -DWITH_AUDIT=OFF -DWITH_SELINUX=OFF -DWITH_SEQUOIA=OFF -DWITH_DBUS=OFF -DZSTD_INCLUDE_DIR=\"\${ZSTD_HOME}/include\" -DZSTD_LIBRARY=\"\${ZSTD_HOME}/lib\" -DHAVE_UNSHARE=OFF -DENABLE_PYTHON=OFF"
+
+export ZOPEN_CONFIGURE_OPTS="--install-prefix \$ZOPEN_INSTALL_DIR/ -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_SYSTEM_PREFIX_PATH=/data/zopen/usr/local/zopen/ -DZLIB_LIBRARY=\"\$ZLIB_HOME/lib/libz.a\" -DLUA_DIR=\"\$LUA_HOME\" -DLUA_LIBRARIES=\"\$LUA_HOME/lib/liblua.a\" -DLUA_INCLUDE_DIR=\$LUA_HOME/include -DBZIP2_INCLUDE_DIR=\$BZIP2_HOME/include -DBZIP2_LIBRARIES=\$BZIP2_HOME/lib/libbz2.a -DLIBARCHIVE_DIR=\$LIBARCHIVE_HOME -DLIBARCHIVE_INCLUDE_DIR=\$LIBARCHIVE_HOME/include -DLIBARCHIVE_LIBRARY=\$LIBARCHIVE_HOME/lib/libarchive.a -DMAGIC_LIBRARY=\$FILE_HOME/lib/libmagic.a -DMAGIC_INCLUDE_DIR=\$FILE_HOME/include -DINTL_LIBRARY=\$GETTEXT_HOME/lib/libintl.a -DINTL_INCLUDE_DIR=\$GETTEXT_HOME/include/libintl.h -DWITH_READLINE=OFF  -DWITH_LIBELF=OFF -DWITH_LIBDW=OFF -DWITH_LIBLZMA=OFF -DENABLE_OPENMP=OFF -DWITH_CAP=OFF -DWITH_ACL=OFF -DWITH_AUDIT=OFF -DWITH_SELINUX=OFF -DWITH_SEQUOIA=OFF -DWITH_DBUS=OFF -DZSTD_INCLUDE_DIR=\"\${ZSTD_HOME}/include\" -DZSTD_LIBRARY=\"\${ZSTD_HOME}/lib\" -DHAVE_UNSHARE=OFF -DENABLE_PYTHON=OFF"
 
 zopen_append_to_env()
 {
@@ -59,12 +66,10 @@ if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
 export PKG_CONFIG_PATH="/data/zopen/usr/local/zopen/popt/popt-master/lib/pkgconfig/:/data/zopen/usr/local/zopen/libarchive/lib/pkgconfig/:\${PKG_CONFIG_PATH}"
 
 
-  # Lua configuration for CMake
   export LUA_DIR=/data/zopen/usr/local/zopen/lua/lua
   export LUA_LIBRARIES=/data/zopen/usr/local/zopen/lua/lua/lib/liblua.a
   export LUA_INCLUDE_DIR=/data/zopen/usr/local/zopen/lua/lua/include
 
-  # Libarchive configuration for CMake
   export LIBARCHIVE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive
   export LIBARCHIVE_LIBRARIES=/data/zopen/usr/local/zopen/libarchive/libarchive/lib/libarchive.a
   export LIBARCHIVE_INCLUDE_DIR=/data/zopen/usr/local/zopen/libarchive/libarchive/include

--- a/cicd-dev.groovy
+++ b/cicd-dev.groovy
@@ -1,0 +1,14 @@
+node('linux')
+{
+  stage ('Poll') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: '*/main']],
+      doGenerateSubmoduleConfigurations: false,
+      extensions: [],
+      userRemoteConfigs: [[url: 'https://github.com/zopencommunity/RPMport.git']]])
+  }
+  stage('Build') {
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/RPMport.git'), string(name: 'PORT_DESCRIPTION', value: 'The RPM package manager' ), string(name: 'BUILD_LINE', value: 'DEV') ]
+  }
+}

--- a/cicd-stable.groovy
+++ b/cicd-stable.groovy
@@ -1,0 +1,14 @@
+node('linux')
+{
+  stage ('Poll') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: '*/main']],
+      doGenerateSubmoduleConfigurations: false,
+      extensions: [],
+      userRemoteConfigs: [[url: 'https://github.com/zopencommunity/RPMport.git']]])
+  }
+  stage('Build') {
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/RPMport.git'), string(name: 'PORT_DESCRIPTION', value: 'The RPM package manager' ), string(name: 'BUILD_LINE', value: 'STABLE') ]
+  }
+}

--- a/patches/CMakeLists.txt.patch
+++ b/patches/CMakeLists.txt.patch
@@ -1,0 +1,59 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 769fcd3..73de61e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,7 +9,7 @@ project(rpm
+
+ # user configurable stuff
+ option(ENABLE_CUTF8 "Enable C.UTF-8 as default locale" ON)
+-option(ENABLE_NLS "Enable native language support" ON)
++option(ENABLE_NLS "Enable native language support" OFF)
+ option(ENABLE_OPENMP "Enable OpenMP threading support" ON)
+ option(ENABLE_PYTHON "Enable Python bindings" ON)
+ option(ENABLE_PLUGINS "Enable plugin support" ON)
+@@ -196,15 +196,26 @@ set(REQFUNCS
+        mkstemp getcwd basename dirname realpath setenv unsetenv regcomp
+        utimes getline localtime_r statvfs getaddrinfo
+        openat mkdirat fstatat linkat symlinkat mkfifoat mknodat unlinkat
+-       renameat utimensat fchmodat fchownat stpcpy stpncpy
++       renameat utimensat fchmodat fchownat
+ )
+
+ find_package(PkgConfig REQUIRED)
+ find_package(Lua 5.2 REQUIRED)
+ find_package(ZLIB REQUIRED)
++
+ if (WITH_BZIP2)
+     find_package(BZip2 REQUIRED)
++    # Check if the target exists, if not create it
++endif()
++
++if(BZip2_FOUND AND NOT TARGET BZip2::BZip2)
++    add_library(BZip2::BZip2 UNKNOWN IMPORTED)
++    set_target_properties(BZip2::BZip2 PROPERTIES
++        IMPORTED_LOCATION "${BZIP2_LIBRARIES}"
++        INTERFACE_INCLUDE_DIRECTORIES "${BZIP2_INCLUDE_DIR}"
++    )
+ endif()
++
+ if (WITH_ICONV)
+     find_package(Iconv REQUIRED)
+ endif()
+@@ -391,7 +402,7 @@ if (LIBDW_FOUND)
+        set(HAVE_LIBDW 1)
+        check_library_exists(dw dwelf_elf_begin "" HAVE_DWELF_ELF_BEGIN)
+ endif()
+-
++set(HAVE_SETPROGNAME 1)
+ check_symbol_exists(GLOB_ONLYDIR "glob.h" HAVE_GLOB_ONLYDIR)
+ check_symbol_exists(major "sys/sysmacros.h" MAJOR_IN_SYSMACROS)
+ if (NOT MAJOR_IN_SYSMACROS)
+ @@ -553,7 +564,7 @@ install(FILES
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rpm
+ )
+
+-export(TARGETS librpm librpmio librpmbuild librpmsign
++export(TARGETS librpm rpmio librpmbuild librpmsign
+        FILE rpm-targets.cmake
+        NAMESPACE rpm::
+ )

--- a/patches/argv.cc.patch
+++ b/patches/argv.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/rpmio/argv.cc b/rpmio/argv.cc
+index 7815a70..d329e10 100644
+--- a/rpmio/argv.cc
++++ b/rpmio/argv.cc
+@@ -8,8 +8,6 @@
+ #include <rpm/argv.h>
+ #include <rpm/rpmstring.h>
+
+-#include "debug.h"
+-
+ void argvPrint(const char * msg, ARGV_const_t argv, FILE * fp)
+ {
+     ARGV_const_t av;

--- a/patches/argv.h.patch
+++ b/patches/argv.h.patch
@@ -1,0 +1,22 @@
+diff --git a/include/rpm/argv.h b/include/rpm/argv.h
+index 9be46d4..e79d54e 100644
+--- a/include/rpm/argv.h
++++ b/include/rpm/argv.h
+@@ -183,6 +183,17 @@ int argvSplit(ARGV_t * argvp, const char * str, const char * seps);
+  */
+ char *argvJoin(ARGV_const_t argv, const char *sep);
+
++#ifndef HAVE_STPCPY
++static char *stpcpy(char *dest, const char *src)
++{
++    while ((*dest = *src) != '\0') {
++        dest++;
++        src++;
++    }
++    return dest;
++}
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif

--- a/patches/build.CMakeLists.txt.patch
+++ b/patches/build.CMakeLists.txt.patch
@@ -1,0 +1,41 @@
+diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
+index 0f561ab..0a141d2 100644
+--- a/build/CMakeLists.txt
++++ b/build/CMakeLists.txt
+@@ -1,8 +1,9 @@
+-add_library(librpmbuild SHARED)
++add_library(librpmbuild STATIC ../lib/backend/ndb/rpmidx.c)
+ set_target_properties(librpmbuild PROPERTIES
+ 	VERSION ${RPM_LIBVERSION}
+ 	SOVERSION ${RPM_SOVERSION}
+ )
++
+ target_sources(librpmbuild PRIVATE
+ 	build.cc files.cc misc.cc pack.cc
+ 	parseSimpleScript.cc parseChangelog.cc parseDescription.cc
+@@ -25,11 +26,14 @@ target_include_directories(librpmbuild
+ )
+ 
+ target_link_libraries(librpmbuild PUBLIC librpmio librpm librpmsign)
++
++find_package(ZLIB REQUIRED)
+ target_link_libraries(librpmbuild PRIVATE
+-	libmisc
++	$<TARGET_OBJECTS:libmisc>
+ 	PkgConfig::POPT
+ 	LUA::LUA
+ 	MAGIC::MAGIC
++	ZLIB::ZLIB
+ 	${Intl_LIBRARIES}
+ )
+ 
+@@ -57,4 +61,8 @@ if (OpenMP_C_FOUND)
+ 	target_link_libraries(librpmbuild PRIVATE OpenMP::OpenMP_CXX)
+ endif()
+ 
+-install(TARGETS librpmbuild EXPORT rpm-targets)
++install(TARGETS librpmbuild EXPORT rpm-targets
++    ARCHIVE DESTINATION lib
++)
++
++

--- a/patches/config.h.in.patch
+++ b/patches/config.h.in.patch
@@ -1,0 +1,9 @@
+diff --git a/config.h.in b/config.h.in
+index 47a7d86..e1ed151 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -124,3 +124,4 @@
+ #define VERSION "@PROJECT_VERSION@"
+ #define PACKAGE_BUGREPORT "@PROJECT_HOMEPAGE_URL@"
+ #define RPM_VENDOR "@RPM_VENDOR@"
++#define setprogname(pn) ((void)0)

--- a/patches/flock_compat.h.patch
+++ b/patches/flock_compat.h.patch
@@ -1,0 +1,33 @@
+--- /dev/null	2022-09-28 17:05:09 -0500
++++ include/rpm/flock_compat.h	2025-07-03 14:19:52 -0500
+@@ -0,0 +1,30 @@
++/*
++ * File locking constants compatibility header
++ * Provides LOCK_* constants for systems that don't have them
++ */
++
++#ifndef FLOCK_COMPAT_H
++#define FLOCK_COMPAT_H
++
++#ifdef HAVE_SYS_FILE_H
++#include <sys/file.h>
++#endif
++
++/* Define file locking constants if not already defined */
++#ifndef LOCK_SH
++#define LOCK_SH   1    /* shared lock */
++#endif
++
++#ifndef LOCK_EX
++#define LOCK_EX   2    /* exclusive lock */
++#endif
++
++#ifndef LOCK_NB
++#define LOCK_NB   4    /* don't block when locking */
++#endif
++
++#ifndef LOCK_UN
++#define LOCK_UN   8    /* unlock */
++#endif
++
++#endif /* FLOCK_COMPAT_H */

--- a/patches/fsm.cc.patch
+++ b/patches/fsm.cc.patch
@@ -1,0 +1,137 @@
+diff --git a/lib/fsm.cc b/lib/fsm.cc
+index 63580c2..442557a 100644
+--- a/lib/fsm.cc
++++ b/lib/fsm.cc
+@@ -4,6 +4,10 @@
+  */
+ 
+ #include "system.h"
++#if defined(__MVS__)
++#include <sys/time.h>
++#include <sys/sys_time.h>
++#endif
+ 
+ #include <inttypes.h>
+ #include <utime.h>
+@@ -26,7 +30,7 @@
+ #include "rpmug.hh"
+ 
+ #include "debug.h"
+-
++#include<iostream>
+ #define	_FSM_DEBUG	0
+ int _fsm_debug = _FSM_DEBUG;
+ 
+@@ -99,7 +103,7 @@ static int fsmLink(int odirfd, const char *opath, int dirfd, const char *path)
+ static int cap_set_fileat(int dirfd, const char *path, cap_t fcaps)
+ {
+     int fd = -1;
+-    int rc = fsmOpenat(&fd, dirfd, path, O_RDONLY|O_NOFOLLOW, 0);
++    int rc = fsmOpenat(&fd, dirfd, path, O_RDONLY, 0);
+     if (!rc) {
+ 	rc = cap_set_fd(fd, fcaps);
+ 	fsmClose(&fd);
+@@ -302,7 +306,7 @@ static int fsmMkdir(int dirfd, const char *path, mode_t mode)
+ static int fsmOpenat(int *wfdp, int dirfd, const char *path, int flags, int dir)
+ {
+     struct stat lsb, sb;
+-    int sflags = flags | O_NOFOLLOW;
++    int sflags = flags ;// | O_NOFOLLOW;
+     int fd = openat(dirfd, path, sflags);
+     int rc = 0;
+ 
+@@ -360,7 +364,7 @@ static int fsmDoMkDir(rpmPlugins plugins, int dirfd, const char *dn,
+ 	rc = fsmMkdir(dirfd, dn, mode);
+ 
+     if (!rc) {
+-	rc = fsmOpenat(fdp, dirfd, dn, O_RDONLY|O_NOFOLLOW, 1);
++	rc = fsmOpenat(fdp, dirfd, dn, O_RDONLY, 1);
+     }
+ 
+     if (!rc) {
+@@ -416,7 +420,9 @@ static int ensureDir(rpmPlugins plugins, const char *p, int owned, int create,
+ 
+     if (rc) {
+ 	if (!quiet) {
++	    std::cout<<"lib_fsm.cc before"<<std::endl;
+ 	    char *msg = rpmfileStrerror(rc);
++	    std::cout<<"lib_fsm.cc after"<<std::endl;
+ 	    rpmlog(RPMLOG_ERR, _("failed to open dir %s of %s: %s\n"),
+ 		    bn, p, msg);
+ 	    free(msg);
+@@ -615,16 +621,17 @@ static int fsmChmod(int fd, int dirfd, const char *path, mode_t mode)
+     return rc;
+ }
+ 
++/*
+ static int fsmUtime(int fd, int dirfd, const char *path, mode_t mode, time_t mtime)
+ {
+     int rc = 0;
+-    struct timespec stamps[2] = {
++    struct timeval stamps[2] = {
+ 	{ .tv_sec = mtime, .tv_nsec = 0 },
+ 	{ .tv_sec = mtime, .tv_nsec = 0 },
+     };
+ 
+     if (fd >= 0)
+-	rc = futimens(fd, stamps);
++	rc = futimes(fd, stamps);
+     else
+ 	rc = utimensat(dirfd, path, stamps, AT_SYMLINK_NOFOLLOW);
+     
+@@ -632,11 +639,42 @@ static int fsmUtime(int fd, int dirfd, const char *path, mode_t mode, time_t mti
+ 	rpmlog(RPMLOG_DEBUG, " %8s (%d - %d %s, 0x%x) %s\n", __func__,
+ 	       fd, dirfd, path, (unsigned)mtime, (rc < 0 ? strerror(errno) : ""));
+     if (rc < 0)	rc = RPMERR_UTIME_FAILED;
+-    /* ...but utime error is not critical for directories */
++    // ...but utime error is not critical for directories 
+     if (rc && S_ISDIR(mode))
+ 	rc = 0;
+     return rc;
+ }
++*/ 
++
++static int fsmUtime(int fd, int dirfd, const char *path, mode_t mode, time_t mtime)
++{
++    int rc = 0;
++
++    if (fd >= 0) {
++        // futimes() expects struct timeval
++        struct timeval stamps[2] = {
++            { .tv_sec = mtime, .tv_usec = 0 },
++            { .tv_sec = mtime, .tv_usec = 0 },
++        };
++        rc = futimes(fd, stamps);
++    } else {
++        // utimensat() expects struct timespec
++        struct timespec stamps[2] = {
++            { .tv_sec = mtime, .tv_nsec = 0 },
++            { .tv_sec = mtime, .tv_nsec = 0 },
++        };
++        rc = utimensat(dirfd, path, stamps, AT_SYMLINK_NOFOLLOW);
++    }
++
++    if (_fsm_debug)
++        rpmlog(RPMLOG_DEBUG, " %8s (%d - %d %s, 0x%x) %s\n", __func__,
++               fd, dirfd, path, (unsigned)mtime, (rc < 0 ? strerror(errno) : ""));
++    if (rc < 0) rc = RPMERR_UTIME_FAILED;
++    /* ...but utime error is not critical for directories */
++    if (rc && S_ISDIR(mode))
++        rc = 0;
++    return rc;
++}
+ 
+ static int fsmVerify(int dirfd, const char *path, rpmfi fi)
+ {
+@@ -1020,8 +1058,10 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+                 }
+             } else {
+                 /* XXX Special case /dev/log, which shouldn't be packaged anyways */
+-                if (!IS_DEV_LOG(fp->fpath))
++                if (!IS_DEV_LOG(fp->fpath)) {
+                     rc = RPMERR_UNKNOWN_FILETYPE;
++		    std::cout<<"MANUALLY ADDED LOG : rpmerr_unknown_filetyype in libfsm.cc rpmPackageFilesInstallfn"<<std::endl;
++		}
+             }
+ 
+ setmeta:

--- a/patches/fts.c.patch
+++ b/patches/fts.c.patch
@@ -1,0 +1,67 @@
+diff --git a/misc/fts.c b/misc/fts.c
+index bf7fb45..0745592 100644
+--- a/misc/fts.c
++++ b/misc/fts.c
+@@ -37,12 +37,12 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
+ #endif
+ 
+ /* Conditional to set up proper fstat64 implementation */
+-#if defined(hpux) || defined(sun) || (defined(__APPLE__) && defined(_DARWIN_FEATURE_ONLY_64_BIT_INODE))
++#if defined(hpux) || defined(sun) || (defined(__APPLE__) && defined(_DARWIN_FEATURE_ONLY_64_BIT_INODE)) || defined(_MVS_)
+ #   define FTS_FSTAT64(_fd, _sbp)   fstat((_fd), (_sbp))
+ #else
+ #   define FTS_FSTAT64(_fd, _sbp)   fstat64((_fd), (_sbp))
+ #endif
+-
++#   define stat64		stat
+ #if defined(_LIBC)
+ #include <sys/param.h>
+ #include <include/sys/stat.h>
+@@ -56,7 +56,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
+ #else
+ 
+ /* Conditionals for working around non-GNU environments */
+-#if defined(hpux)
++#if defined(hpux) || defined(_MVS_)
+ #   define        _INCLUDE_POSIX_SOURCE
+ #   define __errno_location() 	(&errno)
+ #   define dirfd(dirp)		-1
+@@ -68,7 +68,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
+ #endif
+ #if defined(__APPLE__)
+ #   define __errno_location()	(__error())
+-#if defined(_DARWIN_FEATURE_ONLY_64_BIT_INODE)
++#if defined(_DARWIN_FEATURE_ONLY_64_BIT_INODE) || defined(_MVS_)
+ #		define stat64	stat
+ #endif
+ #endif
+@@ -80,7 +80,8 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
+ #include <dirent.h>
+ #include <errno.h>
+ #include "rpmfts.h"
+-#   define __set_errno(val) (*__errno_location ()) = (val)
++//  #   define __set_errno(val) (*__errno_location ()) = (val)
++#define __set_errno(val) (errno = (val))
+ #   define __open	open
+ #   define __close	close
+ #   define __fchdir	fchdir
+@@ -141,7 +142,8 @@ Fts_open(char * const * argv, int options,
+ 
+ 	/* Options check. */
+ 	if (options & ~FTS_OPTIONMASK) {
+-		__set_errno (EINVAL);
++        	__set_errno (EINVAL);
++	        
+ 		return (NULL);
+ 	}
+ 
+@@ -310,7 +312,8 @@ Fts_close(FTS * sp)
+ 		if (saved_errno != 0) {
+ 			/* Free up the stream pointer. */
+ 			free(sp);
+-			__set_errno (saved_errno);
++		//	__set_errno (saved_errno);
++			errno=saved_errno;
+ 			return (-1);
+ 		}
+ 	}

--- a/patches/headerfmt.cc.patch
+++ b/patches/headerfmt.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/headerfmt.cc b/lib/headerfmt.cc
+index f6cb9fa..f2a25b5 100644
+--- a/lib/headerfmt.cc
++++ b/lib/headerfmt.cc
+@@ -214,7 +214,8 @@ RPM_GNUC_PRINTF(2, 3)
+ static void hsaError(headerSprintfArgs hsa, const char *fmt, ...)
+ {
+     /* Use thread local buffer as headerFormat() errmsg arg is const */
+-    static __thread char *errbuf = NULL;
++    // static __thread char *errbuf = NULL;
++    static char *errbuf = NULL;
+ 
+     if (fmt == NULL) {
+ 	hsa->errmsg = NULL;

--- a/patches/include.rpm.CMakeLists.txt.patch
+++ b/patches/include.rpm.CMakeLists.txt.patch
@@ -1,0 +1,12 @@
+diff --git a/include/rpm/CMakeLists.txt b/include/rpm/CMakeLists.txt
+index 4f58727..fc606e2 100644
+--- a/include/rpm/CMakeLists.txt
++++ b/include/rpm/CMakeLists.txt
+@@ -11,5 +11,7 @@ install(FILES
+        rpmbuild.h rpmspec.h rpmfc.h
+
+        rpmsign.h
++
++
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rpm
+ )

--- a/patches/keystore.cc.patch
+++ b/patches/keystore.cc.patch
@@ -1,0 +1,58 @@
+diff --git a/lib/keystore.cc b/lib/keystore.cc
+index 4eaca9c..1f08519 100644
+--- a/lib/keystore.cc
++++ b/lib/keystore.cc
+@@ -23,6 +23,21 @@
+ 
+ #include "debug.h"
+ 
++#include <rpm/portable_remove_all.h>
++
++#ifndef LOCK_EX
++#define LOCK_EX   2    /* exclusive lock */
++#endif
++#ifndef LOCK_NB
++#define LOCK_NB   4    /* don't block when locking */
++#endif
++#ifndef LOCK_UN
++#define LOCK_UN   8    /* unlock */
++#endif
++#ifndef LOCK_SH
++#define LOCK_SH   1    /* shared lock */
++#endif
++
+ using std::string;
+ using namespace rpm;
+ namespace fs = std::filesystem;
+@@ -117,7 +132,8 @@ exit:
+ static rpmRC delete_file_store(std::string path)
+ {
+     try {
+-	fs::remove_all(path);
++	// fs::remove_all(path);
++	portable_remove_all(path);
+     } catch (std::filesystem::filesystem_error& e) {
+ 	return RPMRC_FAIL;
+     }
+@@ -199,7 +215,9 @@ static int acquire_write_lock(rpmtxn txn)
+ 
+     if ((fd = open(lockpath, O_WRONLY|O_CREAT, 644)) == -1) {
+ 	rpmlog(RPMLOG_ERR, _("Can't create writelock for keyring at %s: %s\n"), keyringpath, strerror(errno));
++    #ifndef __MVS__
+     } else if (flock(fd, LOCK_EX|LOCK_NB)) {
++    #endif 
+ 	rpmlog(RPMLOG_ERR, _("Can't acquire writelock for keyring at %s\n"), keyringpath);
+ 	close(fd);
+ 	fd = -1;
+@@ -212,8 +230,10 @@ static int acquire_write_lock(rpmtxn txn)
+ }
+ 
+ static void free_write_lock(int fd)
+-{
++{ 
++#ifndef __MVS__
+     flock(fd, LOCK_UN);
++#endif
+ }
+ 
+ rpmRC keystore_openpgp_cert_d::load_keys(rpmtxn txn, rpmKeyring keyring)

--- a/patches/lposix.cc.patch
+++ b/patches/lposix.cc.patch
@@ -1,0 +1,28 @@
+diff --git a/rpmio/lposix.cc b/rpmio/lposix.cc
+index 3f66f70..0a4a423 100644
+--- a/rpmio/lposix.cc
++++ b/rpmio/lposix.cc
+@@ -567,9 +567,22 @@ static int Fgetpasswd(lua_State *L, int i, const void *data)
+ 		case 3: lua_pushstring(L, p->pw_dir); break;
+ 		case 4: lua_pushstring(L, p->pw_shell); break;
+ /* not strictly POSIX */
++		/*
+ 		case 5: lua_pushstring(L, p->pw_gecos); break;
+ 		case 6: lua_pushstring(L, p->pw_passwd); break;
+-	}
++		*/
++		/* not strictly POSIX */
++		#if !defined(__BIONIC__) && !defined(__MVS__) && defined(HAVE_PW_GECOS)
++			case 5: lua_pushstring(L, p->pw_gecos); break;
++		#else
++			case 5: lua_pushstring(L, ""); break;  /* Return empty string */
++		#endif
++		#if !defined(__BIONIC__) && !defined(__MVS__) && defined(HAVE_PW_PASSWD)
++			case 6: lua_pushstring(L, p->pw_passwd); break;
++		#else
++			case 6: lua_pushstring(L, "x"); break;  /* Return placeholder */
++		#endif
++      }
+ 	return 1;
+ }
+ 

--- a/patches/macro.cc.patch
+++ b/patches/macro.cc.patch
@@ -1,0 +1,57 @@
+diff --git a/rpmio/macro.cc b/rpmio/macro.cc
+index 21d1757..f4a46a7 100644
+--- a/rpmio/macro.cc
++++ b/rpmio/macro.cc
+@@ -1131,20 +1131,46 @@ static void doShescape(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *pa
+ 	rpmMacroBufAppend(mb, '\'');
+     }
+ }
++// 	PREVIOUSLY DEFINED BY RPM 
++//	static uint64_t getmem_total(void)
++//	{
++//	    uint64_t mem = 0;
++//	    long int pagesize = sysconf(_SC_PAGESIZE);
++//	    long int pages = sysconf(_SC_PHYS_PAGES);
++//
++//	    if (pagesize <= 0)
++//		pagesize = 4096;
++//	    if (pages > 0) {
++//		/* Cast needed to force 64bit calculation on 32bit systems */
++//		mem = (uint64_t)pages * pagesize;
++//	    }
++//
++//	    return mem;
++//	}
+ 
+ static uint64_t getmem_total(void)
+ {
+     uint64_t mem = 0;
+     long int pagesize = sysconf(_SC_PAGESIZE);
+-    long int pages = sysconf(_SC_PHYS_PAGES);
+ 
+     if (pagesize <= 0)
+-	pagesize = 4096;
+-    if (pages > 0) {
+-	/* Cast needed to force 64bit calculation on 32bit systems */
+-	mem = (uint64_t)pages * pagesize;
++        pagesize = 4096;
++
++   /* Fallback: try to read from /proc/meminfo on Linux-like systems-> __MVS__ which is zopen's indicates that the host operating system is z/OS */
++    FILE *fp = fopen("/proc/meminfo", "r");
++    if (fp) {
++        char line[256];
++        while (fgets(line, sizeof(line), fp)) {
++            if (strncmp(line, "MemTotal:", 9) == 0) {
++                unsigned long kb;
++                if (sscanf(line + 9, "%lu", &kb) == 1) {
++                    mem = (uint64_t)kb * 1024;
++                }
++                break;
++            }
++        }
++        fclose(fp);
+     }
+-
+     return mem;
+ }
+ 

--- a/patches/macros.in.patch
+++ b/patches/macros.in.patch
@@ -1,0 +1,59 @@
+diff --git a/macros.in b/macros.in
+index e3741f9..de8bf36 100644
+--- a/macros.in
++++ b/macros.in
+@@ -1339,55 +1339,4 @@ end
+ # arguments, eg `%add_sysuser g mygroup 515`.
+ # -b option omits the "Provides: " and the "Requires:" lines for group
+ # membership to support formatting the entry outside spec context.
+-%add_sysuser(-) %{lua:
+-    if arg[1] == '-b' then
+-        prefix = ''
+-        table.remove(arg, 1)
+-    else
+-        prefix = 'Provides: '
+-    end
+-    if #arg < 2 then
+-        macros.error({'not enough arguments'})
+-    end
+-    name = arg[2]
+-    if arg[1] == 'g' then
+-        type = 'group'
+-    elseif arg[1] == 'u' or arg[1] == 'u!' then
+-        type = 'user'
+-    elseif arg[1] == 'm' and #arg >=3 then
+-        type = 'groupmember'
+-    elseif arg[1] == 'r' then
+-        macros.warn({'ignoring unsupported sysuser type: '..arg[1]})
+-        return
+-    else
+-        macros.error({'invalid sysuser type: '..arg[1]})
+-    end
+-    line = table.concat(arg, ' ')
+-    -- \0-pad source string to avoid '=' in the output
+-    llen = line:len()
+-    ulen = math.ceil(4 * (llen / 3))
+-    plen = 4 * math.ceil(llen / 3)
+-    pad = string.rep('\\0', plen-ulen)
+-    enc = rpm.b64encode(line..pad, 0);
+-
+-    if type == 'groupmember' then
+-        print(string.format('%s%s(%s/%s) = %s\\n', prefix, type, name, arg[3], enc))
+-       if (prefix ~= '') then
+-          prefix2 = rpm.expand('%[%{?_use_weak_usergroup_deps} > 0 : "Recommends" : "Requires"]')
+-          print(string.format('%s: user(%s)\\n', prefix2, name))
+-          print(string.format('%s: group(%s)\\n', prefix2, arg[3]))
+-       end
+-    else
+-        print(string.format('%s%s(%s) = %s\\n', prefix, type, name, enc))
+-    end
+-    if type == 'user' then
+-        print(string.format('%s%s(%s)\\n', prefix, 'group', name))
+-    end
+-}
+-
+-# Global buildsystem defaults
+-%buildsystem_default_prep() %autosetup -C -p1 %*
+-
+-# \endverbatim
+-#*/

--- a/patches/misc.CMakeLists.txt.patch
+++ b/patches/misc.CMakeLists.txt.patch
@@ -1,0 +1,9 @@
+diff --git a/misc/CMakeLists.txt b/misc/CMakeLists.txt
+index 925d2ea..20f6016 100644
+--- a/misc/CMakeLists.txt
++++ b/misc/CMakeLists.txt
+@@ -1,2 +1,4 @@
+ add_library(libmisc OBJECT fts.c rpmfts.h)
+ target_include_directories(libmisc PRIVATE ${Intl_INCLUDE_DIRS})
++
++

--- a/patches/pack.cc.patch
+++ b/patches/pack.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/build/pack.cc b/build/pack.cc
+index 93e3703..46846a2 100644
+--- a/build/pack.cc
++++ b/build/pack.cc
+@@ -25,7 +25,7 @@
+ #include "rpmmacro_internal.hh"
+
+ #include "debug.h"
+-
++#include<iostream>
+ static int rpmPackageFilesArchive(rpmfiles fi, int isSrc,
+                                  FD_t cfd, ARGV_t dpaths,
+                                  rpm_loff_t * archiveSize, char ** failedFile)
+@@ -94,7 +94,9 @@ static rpmRC cpio_doio(FD_t fdo, Package pkg, const char * fmodeMacro,
+     fdFiniDigest(cfd, RPMTAG_PAYLOADSHA3_256ALT, (void **)pld3, NULL, 1);
+
+     if (fsmrc) {
++       std::cout<<"build_pack.cc before"<<std::endl;
+        char *emsg = rpmfileStrerror(fsmrc);
++       std::cout<<"build_pack.cc after"<<std::endl;
+        if (failedFile)
+            rpmlog(RPMLOG_ERR, _("create archive failed on file %s: %s\n"),
+                   failedFile, emsg);

--- a/patches/poptALL.cc.patch
+++ b/patches/poptALL.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/poptALL.cc b/lib/poptALL.cc
+index 100c13e..3d99874 100644
+--- a/lib/poptALL.cc
++++ b/lib/poptALL.cc
+@@ -13,6 +13,8 @@
+
+ #include "debug.h"
+
++#include <rpm/progname_fallback.h>
++
+ #define POPT_SHOWVERSION       -999
+ #define POPT_SHOWRC            -998
+ #define POPT_QUERYTAGS         -997

--- a/patches/portable_remove_all.h.patch
+++ b/patches/portable_remove_all.h.patch
@@ -1,0 +1,48 @@
+--- /dev/null	2022-09-28 17:05:09 -0500
++++ include/rpm/portable_remove_all.h	2025-07-01 13:53:20 -0500
+@@ -0,0 +1,45 @@
++/* taken from patchfile https://github.com/zopencommunity/ccacheport/blob/cdbb97517b6884c7f57526fbb60562085809d85b/patches/PR1.patch#L101 */
++#include <dirent.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include <sys/types.h>
++#include <cstdio>
++#include <cstring>
++#include <string>
++#include <cerrno>
++#include <stdexcept>
++
++inline std::uintmax_t portable_remove_all(const std::string& path) {
++	std::uintmax_t count = 0;
++	struct stat path_stat{};
++
++	if (lstat(path.c_str(), &path_stat) != 0) {
++		if (errno == ENOENT) return 0;
++		throw std::runtime_error("lstat failed: " + path + ": " + std::strerror(errno));
++	}
++
++	if (S_ISDIR(path_stat.st_mode)) {
++		DIR* dir = opendir(path.c_str());
++		if (!dir) throw std::runtime_error("opendir failed: " + path + ": " + std::strerror(errno));
++
++		struct dirent* entry;
++		while ((entry = readdir(dir)) != nullptr) {
++			std::string name = entry->d_name;
++			if (name == "." || name == "..") continue;
++			count += portable_remove_all(path + "/" + name);
++		}
++		closedir(dir);
++		if (rmdir(path.c_str()) != 0) {
++			throw std::runtime_error("rmdir failed: " + path + ": " + std::strerror(errno));
++		}
++		count++;
++	} else {
++		if (unlink(path.c_str()) != 0) {
++			throw std::runtime_error("unlink failed: " + path + ": " + std::strerror(errno));
++		}
++		count++;
++	}
++
++	return count;
++}
++

--- a/patches/rpm.cc.patch
+++ b/patches/rpm.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/rpm.cc b/tools/rpm.cc
+index 6be1bf0..b950c27 100644
+--- a/tools/rpm.cc
++++ b/tools/rpm.cc
+@@ -7,6 +7,8 @@
+ #include <rpm/rpmstring.h>
+ #include <rpm/rpmts.h>
+
++#include <rpm/progname_fallback.h>
++
+ #include "cliutils.hh"
+
+ #include "debug.h"
+@@ -75,7 +77,7 @@ int main(int argc, char *argv[])
+     /* Set the major mode based on argv[0] */
+     if (rstreq(xgetprogname(), "rpmquery"))    bigMode = MODE_QUERY;
+     if (rstreq(xgetprogname(), "rpmverify")) bigMode = MODE_VERIFY;
+-
++
+     /* Jumpstart option from argv[0] if necessary. */
+     switch (bigMode) {
+     case MODE_QUERY:   qva->qva_mode = 'q';    break;

--- a/patches/rpmfc.cc.patch
+++ b/patches/rpmfc.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/build/rpmfc.cc b/build/rpmfc.cc
+index ac6b394..f986d98 100644
+--- a/build/rpmfc.cc
++++ b/build/rpmfc.cc
+@@ -51,7 +51,7 @@ struct rpmfcFileDep {
+     int fileIx;
+     rpmds dep;
+ 
+-    bool operator < (const rpmfcFileDep & other) {
++    bool operator < (const rpmfcFileDep & other) const {
+ 	return fileIx < other.fileIx;
+     }
+ };

--- a/patches/rpmglob.cc.patch
+++ b/patches/rpmglob.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/rpmio/rpmglob.cc b/rpmio/rpmglob.cc
+index eb439ca..cbd4486 100644
+--- a/rpmio/rpmglob.cc
++++ b/rpmio/rpmglob.cc
+@@ -80,10 +80,13 @@ int rpmGlobPath(const char * pattern, rpmglobFlags flags,
+ 	argvAdd(argvPtr, pattern);
+ 	goto exit;
+     }
+-
++#ifdef GLOB_BRACE
+     gflags |= GLOB_BRACE;
+-    if (home != NULL && strlen(home) > 0) 
++#endif
++    if (home != NULL && strlen(home) > 0)
++#ifdef GLOB_TILDE 
+ 	gflags |= GLOB_TILDE;
++#endif
+ #if HAVE_GLOB_ONLYDIR
+     if (dir_only)
+ 	gflags |= GLOB_ONLYDIR;

--- a/patches/rpmidx.c.patch
+++ b/patches/rpmidx.c.patch
@@ -1,0 +1,43 @@
+diff --git a/lib/backend/ndb/rpmidx.c b/lib/backend/ndb/rpmidx.c
+index 5b2b7b3..433ea7f 100644
+--- a/lib/backend/ndb/rpmidx.c
++++ b/lib/backend/ndb/rpmidx.c
+@@ -20,9 +20,37 @@
+ #define htole32(x) OSSwapHostToLittleInt32(x)
+ #define le32toh(x) OSSwapLittleToHostInt32(x)
+ #else
+-#include <endian.h>
++// #include <endian.h>
++#include <sys/endian.h>
+ #endif /* __APPLE__ */
+ 
++
++#ifdef __MVS__
++#include <stdint.h>
++#define htole16(x) __bswap16(x)
++#define le16toh(x) __bswap16(x)
++#define htole32(x) __bswap32(x)
++#define le32toh(x) __bswap32(x)
++#define htole64(x) __bswap64(x)
++#define le64toh(x) __bswap64(x)
++
++static __inline uint16_t __bswap16(uint16_t __x)
++{
++	return __x<<8 | __x>>8;
++}
++
++static __inline uint32_t __bswap32(uint32_t __x)
++{
++	return __x>>24 | __x>>8&0xff00 | __x<<8&0xff0000 | __x<<24;
++}
++
++static __inline uint64_t __bswap64(uint64_t __x)
++{
++	return __bswap32(__x)+0ULL<<32 | __bswap32(__x>>32);
++}
++
++#endif
++
+ #include "rpmidx.h"
+ #include "rpmxdb.h"
+ 

--- a/patches/rpmio.CMakeLists.txt.patch
+++ b/patches/rpmio.CMakeLists.txt.patch
@@ -1,0 +1,96 @@
+diff --git a/rpmio/CMakeLists.txt b/rpmio/CMakeLists.txt
+index 3148522..e63bf57 100644
+--- a/rpmio/CMakeLists.txt
++++ b/rpmio/CMakeLists.txt
+@@ -1,14 +1,14 @@
+-add_library(librpmio SHARED)
++add_library(rpmio STATIC)
+ 
+-target_sources(librpmio PRIVATE
++target_sources(rpmio PRIVATE
+ 	argv.cc base64.cc digest.cc expression.cc macro.cc rpmhook.hh rpmhook.cc
+ 	rpmio.cc rpmlog.cc rpmmalloc.cc rgetopt.cc rpmpgp.cc rpmpgpval.hh
+ 	rpmsq.cc rpmsw.cc url.cc rpmio_internal.hh rpmvercmp.cc
+ 	rpmver.cc rpmstring.cc rpmfileutil.cc rpmglob.cc rpmkeyring.cc
+ 	rpmstrpool.cc rpmmacro_internal.hh rpmlua.cc rpmlua.hh lposix.cc
+ )
+-target_compile_definitions(librpmio PRIVATE RPM_CONFIGDIR="${RPM_CONFIGDIR}")
+-target_include_directories(librpmio 
++target_compile_definitions(rpmio PRIVATE RPM_CONFIGDIR="${RPM_CONFIGDIR}")
++target_include_directories(rpmio 
+     PRIVATE
+ 	${CMAKE_CURRENT_SOURCE_DIR}
+ 	${Intl_INCLUDE_DIRS}
+@@ -23,30 +23,30 @@ endif()
+ 
+ if (WITH_SEQUOIA)
+ 	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.8.0)
+-	target_sources(librpmio PRIVATE rpmpgp_sequoia.cc)
+-	target_link_libraries(librpmio PRIVATE PkgConfig::RPMSEQUOIA)
++	target_sources(rpmio PRIVATE rpmpgp_sequoia.cc)
++	target_link_libraries(rpmio PRIVATE PkgConfig::RPMSEQUOIA)
+ else()
+ 	if (WITH_LEGACY_OPENPGP)
+-		target_link_libraries(librpmio PRIVATE rpmpgp_legacy)
++		target_link_libraries(rpmio PRIVATE rpmpgp_legacy)
+ 	else()
+-		target_sources(librpmio PRIVATE rpmpgp_dummy.cc)
++		target_sources(rpmio PRIVATE rpmpgp_dummy.cc)
+ 	endif()
+ 	if (WITH_OPENSSL)
+ 		find_package(OpenSSL 1.0.2 REQUIRED)
+-		target_sources(librpmio PRIVATE digest_openssl.cc)
+-		target_link_libraries(librpmio PRIVATE OpenSSL::Crypto)
++		target_sources(rpmio PRIVATE digest_openssl.cc)
++		target_link_libraries(rpmio PRIVATE OpenSSL::Crypto)
+ 	else()
+ 		pkg_check_modules(LIBGCRYPT REQUIRED IMPORTED_TARGET libgcrypt)
+-		target_sources(librpmio PRIVATE digest_libgcrypt.cc)
+-		target_link_libraries(librpmio PRIVATE PkgConfig::LIBGCRYPT)
++		target_sources(rpmio PRIVATE digest_libgcrypt.cc)
++		target_link_libraries(rpmio PRIVATE PkgConfig::LIBGCRYPT)
+ 	endif()
+ endif()
+ 
+-set_target_properties(librpmio PROPERTIES
++set_target_properties(rpmio PROPERTIES
+ 	VERSION ${RPM_LIBVERSION}
+ 	SOVERSION ${RPM_SOVERSION}
+ )
+-target_link_libraries(librpmio PRIVATE
++target_link_libraries(rpmio PRIVATE
+ 	PkgConfig::POPT
+ 	LUA::LUA
+ 	ZLIB::ZLIB
+@@ -54,16 +54,26 @@ target_link_libraries(librpmio PRIVATE
+ )
+ 
+ if (ZSTD_FOUND)
+-	target_link_libraries(librpmio PRIVATE PkgConfig::ZSTD)
++	target_link_libraries(rpmio PRIVATE PkgConfig::ZSTD)
+ endif()
+ if (LIBLZMA_FOUND)
+-	target_link_libraries(librpmio PRIVATE PkgConfig::LIBLZMA)
++	target_link_libraries(rpmio PRIVATE PkgConfig::LIBLZMA)
+ endif()
+ if (BZIP2_FOUND)
+-	target_link_libraries(librpmio PRIVATE BZip2::BZip2)
++    target_link_libraries(rpmio PRIVATE ${BZIP2_LIBRARIES})
++    target_include_directories(rpmio PRIVATE ${BZIP2_INCLUDE_DIR})
++    
++    get_filename_component(BZIP2_LIB_DIR ${BZIP2_LIBRARIES} DIRECTORY)
++    target_link_directories(rpmio PRIVATE ${BZIP2_LIB_DIR})
++    
++    # message(STATUS "  BZIP2_LIBRARIES: ${BZIP2_LIBRARIES}")
++    # message(STATUS "  BZIP2_INCLUDE_DIR: ${BZIP2_INCLUDE_DIR}")
++    # message(STATUS "  BZIP2_LIB_DIR: ${BZIP2_LIB_DIR}")
+ endif()
++
++
+ if (OpenMP_C_FOUND)
+-        target_link_libraries(librpmio PRIVATE OpenMP::OpenMP_C)
++        target_link_libraries(rpmio PRIVATE OpenMP::OpenMP_C)
+ endif()
+ 
+-install(TARGETS librpmio EXPORT rpm-targets)
++install(TARGETS rpmio EXPORT rpm-targets)

--- a/patches/rpmlog.cc.patch
+++ b/patches/rpmlog.cc.patch
@@ -1,0 +1,25 @@
+diff --git a/rpmio/rpmlog.cc b/rpmio/rpmlog.cc
+index b3a2806..b676f54 100644
+--- a/rpmio/rpmlog.cc
++++ b/rpmio/rpmlog.cc
+@@ -259,7 +259,9 @@ static int getColorConfig(void)
+ 
+ static void logerror(void)
+ {
+-    static __thread int lasterr = 0;
++    // static __thread int lasterr = 0;
++    // assuming thread safety isn't critical
++    static int lasterr = 0;
+     if (errno != EPIPE && errno != lasterr) {
+ 	lasterr = errno;
+ 	perror(_("Error writing to log"));
+@@ -269,7 +271,8 @@ static void logerror(void)
+ static int rpmlogDefault(FILE *stdlog, rpmlogRec rec)
+ {
+     FILE *msgout = (stdlog ? stdlog : stderr);
+-    static __thread int color = -1;
++    //static __thread int color = -1;
++    static int color = -1;
+     const char * colorOn = NULL;
+ 
+     if (color < 0)

--- a/patches/rpmpkg.c.patch
+++ b/patches/rpmpkg.c.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/backend/ndb/rpmpkg.c b/lib/backend/ndb/rpmpkg.c
+index 37dd9f4..f94ef50 100644
+--- a/lib/backend/ndb/rpmpkg.c
++++ b/lib/backend/ndb/rpmpkg.c
+@@ -13,6 +13,7 @@
+ #include <libgen.h>
+ #include <dirent.h>
+ 
++#include <rpm/flock_compat.h>
+ #include "rpmpkg.h"
+ 
+ static int rpmpkgVerifyblob(rpmpkgdb pkgdb, unsigned int pkgidx, unsigned int blkoff, unsigned int blkcnt);

--- a/patches/rpmsort.cc.patch
+++ b/patches/rpmsort.cc.patch
@@ -1,0 +1,18 @@
+diff --git a/tools/rpmsort.cc b/tools/rpmsort.cc
+index 183fe69..69b9036 100644
+--- a/tools/rpmsort.cc
++++ b/tools/rpmsort.cc
+@@ -10,6 +10,13 @@
+
+ #define BUFSIZE 2048
+
++#ifdef __MVS__
++static inline char* strchrnul(const char* s, int c) {
++    const char* p = strchr(s, c);
++    return (char*)(p ? p : s + strlen(s));
++}
++#endif
++
+ static size_t read_file(const char *input, char **ret)
+ {
+     FILE *in;

--- a/patches/rpmsq.cc.patch
+++ b/patches/rpmsq.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/rpmio/rpmsq.cc b/rpmio/rpmsq.cc
+index 67824b1..a3e06c7 100644
+--- a/rpmio/rpmsq.cc
++++ b/rpmio/rpmsq.cc
+@@ -5,7 +5,7 @@
+ #include "system.h"
+
+ #include <signal.h>
+-#include <sys/signal.h>
++// #include <sys/signal.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <stdlib.h>

--- a/patches/rpmstrpool.cc.patch
+++ b/patches/rpmstrpool.cc.patch
@@ -1,0 +1,25 @@
+diff --git a/rpmio/rpmstrpool.cc b/rpmio/rpmstrpool.cc
+index 7fd2430..0440a26 100644
+--- a/rpmio/rpmstrpool.cc
++++ b/rpmio/rpmstrpool.cc
+@@ -238,7 +238,9 @@ static void rpmstrPoolRehash(rpmstrPool pool)
+ 
+ rpmstrPool rpmstrPoolCreate(void)
+ {
+-    rpmstrPool pool = (rpmstrPool)xcalloc(1, sizeof(*pool));
++   // rpmstrPool pool = (rpmstrPool)xcalloc(1, sizeof(*pool));
++    rpmstrPool pool = new (std::nothrow) rpmstrPool_s();
++    if (pool == NULL) return NULL; // Check if new failed
+ 
+     pool->offs_alloced = STROFFS_CHUNK;
+     pool->offs = (const char **)xcalloc(pool->offs_alloced, sizeof(*pool->offs));
+@@ -268,7 +270,8 @@ rpmstrPool rpmstrPoolFree(rpmstrPool pool)
+ 	pool->chunks[i] = _free(pool->chunks[i]);
+     }
+     free(pool->chunks);
+-    free(pool);
++    // free(pool);
++    delete pool;
+ 
+     return NULL;
+ }

--- a/patches/rpmug.cc.patch
+++ b/patches/rpmug.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/rpmug.cc b/lib/rpmug.cc
+index 6093cd6..02867fc 100644
+--- a/lib/rpmug.cc
++++ b/lib/rpmug.cc
+@@ -25,7 +25,8 @@ struct rpmug_s {
+     unordered_map<string,gid_t> gnameMap;
+ };
+ 
+-static __thread struct rpmug_s *rpmug = NULL;
++// static __thread struct rpmug_s *rpmug = NULL;
++static struct rpmug_s *rpmug = NULL;
+ 
+ static const char *getpath(const char *bn, const char *dfl, char **dest)
+ {

--- a/patches/rpmver.cc.patch
+++ b/patches/rpmver.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/backend/ndb/rpmpkg.c b/lib/backend/ndb/rpmpkg.c
+index 37dd9f4..f94ef50 100644
+--- a/lib/backend/ndb/rpmpkg.c
++++ b/lib/backend/ndb/rpmpkg.c
+@@ -13,6 +13,7 @@
+ #include <libgen.h>
+ #include <dirent.h>
+ 
++#include <rpm/flock_compat.h>
+ #include "rpmpkg.h"
+ 
+ static int rpmpkgVerifyblob(rpmpkgdb pkgdb, unsigned int pkgidx, unsigned int blkoff, unsigned int blkcnt);

--- a/patches/rpmxdb.c.patch
+++ b/patches/rpmxdb.c.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/backend/ndb/rpmxdb.c b/lib/backend/ndb/rpmxdb.c
+index e9c7233..ce4c8b4 100644
+--- a/lib/backend/ndb/rpmxdb.c
++++ b/lib/backend/ndb/rpmxdb.c
+@@ -18,13 +18,40 @@
+ #define htole32(x) OSSwapHostToLittleInt32(x)
+ #define le32toh(x) OSSwapLittleToHostInt32(x)
+ #else
+-#include <endian.h>
++// #include <endian.h>
++#include <sys/endian.h>
+ #endif /* __APPLE__ */
+ #include <libgen.h>
+ #include <dirent.h>
+ 
+ #include "rpmxdb.h"
+ 
++#ifdef __MVS__
++#include <stdint.h>
++#define htole16(x) __bswap16(x)
++#define le16toh(x) __bswap16(x)
++#define htole32(x) __bswap32(x)
++#define le32toh(x) __bswap32(x)
++#define htole64(x) __bswap64(x)
++#define le64toh(x) __bswap64(x)
++
++static __inline uint16_t __bswap16(uint16_t __x)
++{
++	return __x<<8 | __x>>8;
++}
++
++static __inline uint32_t __bswap32(uint32_t __x)
++{
++	return __x>>24 | __x>>8&0xff00 | __x<<8&0xff0000 | __x<<24;
++}
++
++static __inline uint64_t __bswap64(uint64_t __x)
++{
++	return __bswap32(__x)+0ULL<<32 | __bswap32(__x>>32);
++}
++
++#endif
++
+ typedef struct rpmxdb_s {
+     rpmpkgdb pkgdb;             /* main database */
+     char *filename;

--- a/patches/sign.CMakeLists.txt.patch
+++ b/patches/sign.CMakeLists.txt.patch
@@ -1,0 +1,10 @@
+diff --git a/sign/CMakeLists.txt b/sign/CMakeLists.txt
+index 5c63a62..8c5217d 100644
+--- a/sign/CMakeLists.txt
++++ b/sign/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-add_library(librpmsign SHARED)
++add_library(librpmsign STATIC)
+ set_target_properties(librpmsign PROPERTIES
+ 	VERSION ${RPM_LIBVERSION}
+ 	SOVERSION ${RPM_SOVERSION}

--- a/patches/stpcpy_custom.h.patch
+++ b/patches/stpcpy_custom.h.patch
@@ -1,0 +1,14 @@
+--- /dev/null	2022-09-28 17:05:09 -0500
++++ include/rpm/stpcpy_custom.h	2025-06-30 13:15:17 -0500
+@@ -0,0 +1,11 @@
++#include <stdio.h>
++#ifndef HAVE_STPCPY
++static char *stpcpy(char *dest, const char *src)
++{
++    while ((*dest = *src) != '\0') {
++        dest++;
++        src++;
++    }
++    return dest;
++}
++#endif

--- a/patches/system.h.patch
+++ b/patches/system.h.patch
@@ -1,0 +1,33 @@
+diff --git a/misc/system.h b/misc/system.h
+index 36ea094..de9d613 100644
+--- a/misc/system.h
++++ b/misc/system.h
+@@ -77,7 +77,7 @@ extern int fdatasync(int fildes);
+
+    setprogname(*pn) must be the first call in main() in order to set the name
+    as soon as possible. */
+-#if defined(HAVE_SETPROGNAME) /* BSD'ish systems */
++ #if defined(HAVE_SETPROGNAME) || defined(_MVS_) /* BSD'ish systems */
+ # include <stdlib.h> /* Make sure this header is included */
+ # define xsetprogname(pn) setprogname(pn)
+ # define xgetprogname(pn) getprogname(pn)
+@@ -86,13 +86,17 @@ extern int fdatasync(int fildes);
+   extern const char *__progname;
+ # define xgetprogname(pn) __progname
+ #else
+-# error "Did not find any sutable implementation of xsetprogname/xgetprogname"
++/* # error put double quotes Did not find any sutable implementation of xsetprogname/xgetprogname */
++/*# include "progname_fallback.h"*/
++# define xsetprogname(pn) /*setprogname(pn)*/
++# define setprogname(pn)     ((void)0)        /* no-op */
++# define xgetprogname(pn) getprogname()
+ #endif
+
+ /* Take care of NLS matters.  */
+ #if defined(ENABLE_NLS)
+ # include <locale.h>
+-# include <libintl.h>
++
+ # define _(Text) dgettext (PACKAGE, Text)
+ #else
+ # define _(Text) Text

--- a/patches/tools.CMakeLists.txt.patch
+++ b/patches/tools.CMakeLists.txt.patch
@@ -1,0 +1,47 @@
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 819d77f..fd7043a 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -18,7 +18,15 @@ target_link_libraries(rpmlua PRIVATE LUA::LUA)
+ target_link_libraries(rpmbuild PRIVATE librpmbuild)
+ target_link_libraries(rpmspec PRIVATE librpmbuild)
+ target_link_libraries(rpmdeps PRIVATE librpmbuild)
+-target_link_libraries(rpmuncompress PRIVATE PkgConfig::LIBARCHIVE)
++find_package(ZLIB REQUIRED)
++find_package(OpenSSL REQUIRED)
++
++pkg_check_modules(LZ4 IMPORTED_TARGET liblz4)
++if(LZ4_FOUND)
++	message("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIFOUNDLZ4")
++endif()
++
++target_link_libraries(rpmuncompress PRIVATE PkgConfig::LZ4 PkgConfig::LIBARCHIVE ZLIB::ZLIB OpenSSL::Crypto)
+ 
+ if (HAVE_STRCHRNUL)
+ 	add_executable(rpmsort rpmsort.cc)
+@@ -27,7 +35,7 @@ endif()
+ 
+ if (LIBELF_FOUND)
+ 	add_executable(elfdeps elfdeps.cc)
+-	target_link_libraries(elfdeps PRIVATE PkgConfig::LIBELF)
++	target_link_libraries(elfdeps PRIVATE PkgConfig::LIBELF libmisc)
+ 	install(TARGETS elfdeps DESTINATION ${RPM_CONFIGDIR})
+ endif()
+ 
+@@ -40,7 +48,7 @@ if (READLINE_FOUND)
+ endif()
+ 
+ add_executable(rpm2archive rpm2archive.cc)
+-target_link_libraries(rpm2archive PRIVATE PkgConfig::LIBARCHIVE)
++target_link_libraries(rpm2archive PRIVATE PkgConfig::LZ4 PkgConfig::LIBARCHIVE libmisc ZLIB::ZLIB OpenSSL::Crypto) 
+ install(TARGETS rpm2archive)
+ 
+ # Everything links to these
+@@ -49,6 +57,7 @@ foreach(exe ${executables})
+ 	target_link_libraries(${exe} PRIVATE librpmio librpm PkgConfig::POPT)
+ 	target_link_libraries(${exe} PRIVATE ${Intl_LIBRARIES})
+ 	target_include_directories(${exe} PRIVATE ${Intl_INCLUDE_DIRS})
++	#	target_link_libraries(${exe} PRIVATE PkgConfig::LZ4)
+ endforeach()
+ 
+ foreach(cmd rpmverify rpmquery)

--- a/patches/transaction.cc.patch
+++ b/patches/transaction.cc.patch
@@ -1,0 +1,28 @@
+diff --git a/lib/transaction.cc b/lib/transaction.cc
+index 4e5da89..03c4323 100644
+--- a/lib/transaction.cc
++++ b/lib/transaction.cc
+@@ -48,6 +48,23 @@
+ 
+ #include "debug.h"
+ 
++/*
++#define _XPLATFORM_SOURCE
++#include <unistd.h>
++
++int syncfs(int fd);
++*/
++
++#ifdef __MVS__
++#include <unistd.h>
++
++// syncfs implementation for z/OS
++int syncfs(int fd) {
++    // On z/OS, syncfs might not exist, use fsync instead
++    return fsync(fd);
++}
++#endif
++
+ using std::string;
+ using std::vector;
+ 


### PR DESCRIPTION
# Ported RPM to z/OS. 
> minimal working version of RPM package manager 

## Disabled Soft Dependencies : 
- READLINE
- LIBELF
- LIBDW
- LIBLZMA
- OPENMP
- CAP
- ACL
- AUDIT
- SELINUX
- SEQUOIA
- DBUS
- UNSHARE
- PYTHON

## Current Functionality :
- Able to succeed `zopen-build` upto install step.
- rpm binaries generated and installed in the right location.
- Managed to create a `.src.rpm` and  `.rpm` package successfully generated using `rpmbuild`.

## Future Fix : 
- To be able to install the .rpm on the z/os .
- To build a arch. independent package to transfer and install on any linux based system.